### PR TITLE
[Fabric 1.17] Fixed server status inconsitencies caused by long pings

### DIFF
--- a/src/main/java/de/keksuccino/fancymenu/menu/servers/ServerCache.java
+++ b/src/main/java/de/keksuccino/fancymenu/menu/servers/ServerCache.java
@@ -72,12 +72,6 @@ public class ServerCache {
                 serversUpdated.get(ip).playerCountLabel = servers.get(ip).playerCountLabel;
                 serversUpdated.get(ip).playerListSummary = servers.get(ip).playerListSummary;
             }
-            else
-            {
-                //Just here so you can see for yourself that this mod sometimes is stuck ages in the "multiplayer.status.pinging" state
-                //for whatever reason this only happens here and not in minecraft's own server screen.
-                //System.out.println("GOTCHA");
-            }
         }
 
         return serversUpdated.get(ip);

--- a/src/main/java/de/keksuccino/fancymenu/menu/servers/ServerCache.java
+++ b/src/main/java/de/keksuccino/fancymenu/menu/servers/ServerCache.java
@@ -22,7 +22,6 @@ public class ServerCache {
     protected static Map<String, ServerInfo> servers = new HashMap<String, ServerInfo>();
     protected static Map<String, ServerInfo> serversUpdated = new HashMap<String, ServerInfo>();
 
-
     public static void init() {
         new Thread(() -> {
             while (true) {

--- a/src/main/java/de/keksuccino/fancymenu/menu/servers/ServerCache.java
+++ b/src/main/java/de/keksuccino/fancymenu/menu/servers/ServerCache.java
@@ -20,6 +20,8 @@ public class ServerCache {
 
     protected static MultiplayerServerListPinger pinger = new MultiplayerServerListPinger();
     protected static Map<String, ServerInfo> servers = new HashMap<String, ServerInfo>();
+    protected static Map<String, ServerInfo> serversUpdated = new HashMap<String, ServerInfo>();
+
 
     public static void init() {
         new Thread(() -> {
@@ -40,11 +42,13 @@ public class ServerCache {
         }).start();
     }
 
-    public static void cacheServer(ServerInfo server) {
+    public static void cacheServer(ServerInfo server, ServerInfo serverUpdated) {
         if (server.address != null) {
             try {
                 server.ping = -1L;
+                serverUpdated.ping = -1L;
                 servers.put(server.address, server);
+                serversUpdated.put(server.address, serverUpdated);
                 pingServers();
             } catch (Exception e) {
                 e.printStackTrace();
@@ -54,17 +58,40 @@ public class ServerCache {
 
     public static ServerInfo getServer(String ip) {
         if (!servers.containsKey(ip)) {
-            cacheServer(new ServerInfo(ip, ip, false));
+            cacheServer(new ServerInfo(ip, ip, false), new ServerInfo(ip, ip, false));
         }
-        return servers.get(ip);
+
+        //Copy server data from old to new array only when server is done pinging
+        if (servers.get(ip).label != null)
+        {
+            if (!servers.get(ip).label.equals(new TranslatableText("multiplayer.status.pinging")))
+            {
+                serversUpdated.get(ip).ping = servers.get(ip).ping;
+                serversUpdated.get(ip).protocolVersion = servers.get(ip).protocolVersion;
+                serversUpdated.get(ip).label = servers.get(ip).label;
+                serversUpdated.get(ip).version = servers.get(ip).version;
+                serversUpdated.get(ip).playerCountLabel = servers.get(ip).playerCountLabel;
+                serversUpdated.get(ip).playerListSummary = servers.get(ip).playerListSummary;
+            }
+            else
+            {
+                //Just here so you can see for yourself that this mod sometimes is stuck ages in the "multiplayer.status.pinging" state
+                //for whatever reason this only happens here and not in minecraft's own server screen.
+                //System.out.println("GOTCHA");
+            }
+        }
+
+        return serversUpdated.get(ip);
     }
 
     public static void removeServer(String ip) {
         servers.remove(ip);
+        serversUpdated.remove(ip);
     }
 
     public static void clear() {
         servers.clear();
+        serversUpdated.clear();
     }
 
     public static void pingServers() {
@@ -75,6 +102,7 @@ public class ServerCache {
                 new Thread(() -> {
                     try {
                         pinger.add(d, () -> {});
+
                         if (d.playerCountLabel == LiteralText.EMPTY) {
                             d.ping = -1L;
                             d.label = CANT_CONNECT_TEXT;


### PR DESCRIPTION
After I discovered that the server status would often randomly flip between Offline and Online, even though it should be consistent,
I investigated and after many tries found out that the mod sometimes takes longer than the minecraft multiplayer menu to ping for unkown reasons, which results in incorrect results, while the ping is ongoing.

The fix I implemented uses a secondary list to store all old values, and only updates them with new values for the server status, ping, etc when the ping is properly completed ("multiplayer.status.pinging" is longer the label).

Hope this helps, for the future maybe another way of pinging could be used over my quick patch code.