### PR TITLE
Add command functionality back to sendmessage

### DIFF
--- a/src/main/java/de/keksuccino/fancymenu/menu/button/ButtonScriptEngine.java
+++ b/src/main/java/de/keksuccino/fancymenu/menu/button/ButtonScriptEngine.java
@@ -90,7 +90,11 @@ public class ButtonScriptEngine {
 			}
 			if (action.equalsIgnoreCase("sendmessage")) {
 				if (Minecraft.getInstance().level != null) {
-					Minecraft.getInstance().player.chat(value);
+					if (value != "" && value.charAt(0) == '/' ) {
+						Minecraft.getInstance().player.command(value.substring(1));
+					} else {
+						Minecraft.getInstance().player.chat(value);
+					}
 				}
 			}
 			if (action.equalsIgnoreCase("quitgame")) {


### PR DESCRIPTION
Small change that just checks the value of a sendmessage command to see if it starts with a '/', and if so then it'll send it as a command. 

`value.charAt(0)` will throw an error if value is an empty string, hence the checking if its empty before.