### PR TITLE
Example fix of id from negative coordinates

### DIFF
--- a/common/src/main/java/de/keksuccino/fancymenu/customization/widget/ScreenWidgetDiscoverer.java
+++ b/common/src/main/java/de/keksuccino/fancymenu/customization/widget/ScreenWidgetDiscoverer.java
@@ -99,7 +99,11 @@ public class ScreenWidgetDiscoverer {
 		if (widget instanceof AbstractWidget w) {
 			//Skip AbstractSelectionLists so they don't appear as customizable widget
 			if (widget instanceof AbstractSelectionList<?>) return;
-			String idRaw = w.getX() + "" + w.getY();
+			var rawY = w.getY();
+			var absY = rawY < 0 ? rawY * -1 : rawY;
+			var rawX = w.getX();
+			var prefix = rawY < 0 ? (rawX >= 0 ? "-" : "") : "";
+			String idRaw = prefix + rawX + "" + absY;
 			long id = 0;
 			if (MathUtils.isLong(idRaw)) {
 				id = getAvailableIdFromBaseId(Long.parseLong(idRaw), ids);


### PR DESCRIPTION
Hi, Keksuccino, is your mod intended to support negative widget coordinates?

In Mine and Slash mod (for some reason latest version of said mod is not published to the github), they assign negative coordinates to widgets and that produces millions of errors in the log

Returning to my question, does your mod supports negative widget coordinates or it's that mod who should fix coordinates to be only positive?